### PR TITLE
case-sensitive for unix-autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "blueimp/jquery-file-upload"
+    "name": "blueimp/jQuery-File-Upload"
   , "description": "File Upload widget for jQuery."
   , "keywords": ["jquery",
         "file",


### PR DESCRIPTION
name must be case-sensitive for linux/unix-server. if this is not given, autoload wil not found the class